### PR TITLE
ppng.ml → ppng.io

### DIFF
--- a/test/PipingServer.App.Tests/APITests/OriginAPIExample.cs
+++ b/test/PipingServer.App.Tests/APITests/OriginAPIExample.cs
@@ -18,7 +18,7 @@ namespace PipingServer.App.APITests
         {
             get
             {
-                yield return OriginPipingServerUrls(new Uri("https://ppng.ml"));
+                yield return OriginPipingServerUrls(new Uri("https://ppng.io"));
                 yield return OriginPipingServerUrls(new Uri("https://piping-92sr2pvuwg14.runkit.sh"));
                 static object[] OriginPipingServerUrls(Uri Uri) => new object[] { Uri, };
             }


### PR DESCRIPTION
こんにちは。

ppng.ml ドメイン の管理をやめ、ppng.io に移行したので変更させていただきました。 ppng.ml も ppng.io も同じサーバーを向いています。